### PR TITLE
Fix: Add custom MySQL port support and improve error handling

### DIFF
--- a/controllers/mysql_controller.py
+++ b/controllers/mysql_controller.py
@@ -7,7 +7,7 @@ from mysqldb.services.dml import insert_row, insert_multiple_rows, delete_rows, 
 from typing import Optional, Dict, List, Any
 
 @mcp.tool()
-def mysql_get_tables(host:str, user:str, password:str, database:str, port:int = 3307) -> Optional[List[str]] :
+def mysql_get_tables(host:str, user:str, password:str, database:str, port:int = 3306) -> Optional[List[str]] :
     """
     Retrieves the list of table names in a MySQL database.
 
@@ -24,7 +24,7 @@ def mysql_get_tables(host:str, user:str, password:str, database:str, port:int = 
     return get_tables(host=host, user=user, password=password, database=database, port=port)
 
 @mcp.tool()
-def mysql_get_schema(host:str, user:str, password:str, database:str, port:int = 3307) -> Optional[Dict[str, list]] :
+def mysql_get_schema(host:str, user:str, password:str, database:str, port:int = 3306) -> Optional[Dict[str, list]] :
     """
     Retrieves the schema of a given MySQL database as a dictionary.
 
@@ -42,7 +42,7 @@ def mysql_get_schema(host:str, user:str, password:str, database:str, port:int = 
     return get_schema(host=host, user=user, password=password, database=database, port=port)
 
 @mcp.tool()
-def mysql_get_table_description(host:str, user:str, password:str, database:str, table_name:str, port:int = 3307) -> Optional[Dict[str, list]] :
+def mysql_get_table_description(host:str, user:str, password:str, database:str, table_name:str, port:int = 3306) -> Optional[Dict[str, list]] :
     """
     Retrieves the schema of a specific table from a given MySQL database.
 
@@ -61,7 +61,7 @@ def mysql_get_table_description(host:str, user:str, password:str, database:str, 
     return get_table_description(host=host, user=user, password=password, database=database, table_name=table_name, port=port)
 
 @mcp.tool()
-def mysql_get_all_rows(host:str, user:str, password:str, database:str, table_name:str, port:int = 3307) -> Optional[List[Dict]]:
+def mysql_get_all_rows(host:str, user:str, password:str, database:str, table_name:str, port:int = 3306) -> Optional[List[Dict]]:
     """
     Retrieves all rows from the specified table in the given database.
 
@@ -80,7 +80,7 @@ def mysql_get_all_rows(host:str, user:str, password:str, database:str, table_nam
     return get_all_rows(host=host, user=user, password=password, database=database, table_name=table_name, port=port)
 
 @mcp.tool()
-def mysql_get_filtered_rows(host: str, user: str, password: str, database: str, table_name: str, filters: Dict[str, Any], port: int = 3307) -> Optional[List[Dict]]:
+def mysql_get_filtered_rows(host: str, user: str, password: str, database: str, table_name: str, filters: Dict[str, Any], port: int = 3306) -> Optional[List[Dict]]:
     """
     Retrieves rows from the specified table in the given database based on filter criteria.
 
@@ -100,7 +100,7 @@ def mysql_get_filtered_rows(host: str, user: str, password: str, database: str, 
     return get_filtered_rows(host, user, password, database, table_name, filters, port=port)
 
 @mcp.tool()
-def mysql_get_sorted_rows(host: str, user: str, password: str, database: str, table_name: str, sort_by: str, order: str = 'ASC', port: int = 3307)  -> Optional[List[Dict]]:
+def mysql_get_sorted_rows(host: str, user: str, password: str, database: str, table_name: str, sort_by: str, order: str = 'ASC', port: int = 3306)  -> Optional[List[Dict]]:
     """
     Retrieves sorted rows from the specified table.
 
@@ -120,7 +120,7 @@ def mysql_get_sorted_rows(host: str, user: str, password: str, database: str, ta
     return get_sorted_rows(host, user, password, database, table_name, sort_by, order, port=port)
 
 @mcp.tool()
-def mysql_get_limited_rows(host: str, user: str, password: str, database: str, table_name: str, limit: int, offset: int = 0, port: int = 3307)  -> Optional[List[Dict]]:
+def mysql_get_limited_rows(host: str, user: str, password: str, database: str, table_name: str, limit: int, offset: int = 0, port: int = 3306)  -> Optional[List[Dict]]:
     """
     Retrieves a limited number of rows from the specified table.
 
@@ -140,7 +140,7 @@ def mysql_get_limited_rows(host: str, user: str, password: str, database: str, t
     return get_limited_rows(host, user, password, database, table_name, limit, offset, port=port)
 
 @mcp.tool()
-def mysql_get_distinct_values(host: str, user: str, password: str, database: str, table_name: str, column: str, port: int = 3307) -> Optional[List[Any]]:
+def mysql_get_distinct_values(host: str, user: str, password: str, database: str, table_name: str, column: str, port: int = 3306) -> Optional[List[Any]]:
     """
     Retrieves distinct values from a specific column in the given table.
 
@@ -159,7 +159,7 @@ def mysql_get_distinct_values(host: str, user: str, password: str, database: str
     return get_distinct_values(host, user, password, database, table_name, column, port=port)
 
 @mcp.tool()
-def mysql_get_aggregated_data(host: str, user: str, password: str, database: str, table_name: str, aggregation: str, column: str, port: int = 3307) -> Optional[Any]:
+def mysql_get_aggregated_data(host: str, user: str, password: str, database: str, table_name: str, aggregation: str, column: str, port: int = 3306) -> Optional[Any]:
     """
     Retrieves aggregated data from a specified column in the given table.
 
@@ -174,7 +174,7 @@ def mysql_get_aggregated_data(host: str, user: str, password: str, database: str
     return get_aggregated_data(host, user, password, database, table_name, aggregation, column, port=port)
 
 @mcp.tool()
-def mysql_get_grouped_data(host: str, user: str, password: str, database: str, table_name: str, group_by: str, aggregation: str, column: str, port: int = 3307) -> Optional[Dict[str, Any]]:
+def mysql_get_grouped_data(host: str, user: str, password: str, database: str, table_name: str, group_by: str, aggregation: str, column: str, port: int = 3306) -> Optional[Dict[str, Any]]:
     """
     Groups data by a specified column and applies an aggregation function.
 
@@ -196,7 +196,7 @@ def mysql_get_grouped_data(host: str, user: str, password: str, database: str, t
     return get_grouped_data(host, user, password, database, table_name, group_by, aggregation, column, port=port)
 
 @mcp.tool()
-def mysql_create_table(host:str, user:str, password:str, database:str, table_name:str, columns: Dict[str, str], options: Optional[Dict[str, str]] = None, port: int = 3307) -> bool:
+def mysql_create_table(host:str, user:str, password:str, database:str, table_name:str, columns: Dict[str, str], options: Optional[Dict[str, str]] = None, port: int = 3306) -> bool:
     """
     Creates a table with the specified columns and options.
     Args:
@@ -214,7 +214,7 @@ def mysql_create_table(host:str, user:str, password:str, database:str, table_nam
     return create_table(host, user, password, database, table_name, columns, options, port=port)
 
 @mcp.tool()
-def mysql_drop_table(host: str, user: str, password: str, database: str, table_name: str, port: int = 3307) -> bool:
+def mysql_drop_table(host: str, user: str, password: str, database: str, table_name: str, port: int = 3306) -> bool:
     """
     Drops the specified table.
     Args:
@@ -230,7 +230,7 @@ def mysql_drop_table(host: str, user: str, password: str, database: str, table_n
     return drop_table(host, user, password, database, table_name, port=port)
 
 @mcp.tool()
-def mysql_show_indexes(host: str, user: str, password: str, database: str, table_name: str, port: int = 3307) -> Optional[List[Dict[str, str]]]:
+def mysql_show_indexes(host: str, user: str, password: str, database: str, table_name: str, port: int = 3306) -> Optional[List[Dict[str, str]]]:
     """
     Retrieves all indexes from a given table.
     Args:
@@ -246,7 +246,7 @@ def mysql_show_indexes(host: str, user: str, password: str, database: str, table
     return show_indexes(host, user, password, database, table_name, port=port)
 
 @mcp.tool()
-def mysql_create_index(host: str, user: str, password: str, database: str, table_name: str, index_name: str, columns: List[str], unique: bool = False, port: int = 3307) -> bool:
+def mysql_create_index(host: str, user: str, password: str, database: str, table_name: str, index_name: str, columns: List[str], unique: bool = False, port: int = 3306) -> bool:
     """
     Creates an index on the specified columns of a table.
     Args:
@@ -265,7 +265,7 @@ def mysql_create_index(host: str, user: str, password: str, database: str, table
     return create_index(host, user, password, database, table_name, index_name, columns, unique, port=port)
 
 @mcp.tool()
-def mysql_insert_row(host:str, user:str, password:str, database:str, table_name:str, data:Dict[str, Any], port: int = 3307) -> bool :
+def mysql_insert_row(host:str, user:str, password:str, database:str, table_name:str, data:Dict[str, Any], port: int = 3306) -> bool :
     """
     Inserts a single row into the specified table.
 
@@ -284,7 +284,7 @@ def mysql_insert_row(host:str, user:str, password:str, database:str, table_name:
     return insert_row(host, user, password, database, table_name, data, port=port)
 
 @mcp.tool()
-def mysql_insert_multiple_rows(host: str, user: str, password: str, database: str, table_name: str, data: List[Dict[str, Any]], port: int = 3307) -> bool:
+def mysql_insert_multiple_rows(host: str, user: str, password: str, database: str, table_name: str, data: List[Dict[str, Any]], port: int = 3306) -> bool:
     """
     Inserts multiple rows into the specified table.
 
@@ -303,7 +303,7 @@ def mysql_insert_multiple_rows(host: str, user: str, password: str, database: st
     return insert_multiple_rows(host, user, password, database, table_name, data, port=port)
 
 @mcp.tool()
-def mysql_delete_rows(host: str, user: str, password: str, database: str, table_name: str, conditions: Dict[str, Any], port: int = 3307) -> bool:
+def mysql_delete_rows(host: str, user: str, password: str, database: str, table_name: str, conditions: Dict[str, Any], port: int = 3306) -> bool:
     """
     Deletes rows from the specified table based on conditions.
 
@@ -322,7 +322,7 @@ def mysql_delete_rows(host: str, user: str, password: str, database: str, table_
     return delete_rows(host, user, password, database, table_name, conditions, port=port)
 
 @mcp.tool()
-def mysql_update_rows(host: str, user: str, password: str, database: str, table_name: str, data: Dict[str, Any], conditions: Dict[str, Any], port: int = 3307) -> bool:
+def mysql_update_rows(host: str, user: str, password: str, database: str, table_name: str, data: Dict[str, Any], conditions: Dict[str, Any], port: int = 3306) -> bool:
     """
     Updates rows in the specified table based on conditions.
 
@@ -342,7 +342,7 @@ def mysql_update_rows(host: str, user: str, password: str, database: str, table_
     return update_rows(host, user, password, database, table_name, data, conditions, port=port)
 
 @mcp.tool()
-def mysql_execute_custom_query(host: str, user: str, password: str, database: str, query: str, port: int = 3307) -> Optional[List[Dict]]:
+def mysql_execute_custom_query(host: str, user: str, password: str, database: str, query: str, port: int = 3306) -> Optional[List[Dict]]:
     """
     Executes a custom SQL query and returns the result as a list of dictionaries. Only use this if necessary like for complex queries. Reply on built in methods to execute queries.
 

--- a/controllers/mysql_controller.py
+++ b/controllers/mysql_controller.py
@@ -7,7 +7,7 @@ from mysqldb.services.dml import insert_row, insert_multiple_rows, delete_rows, 
 from typing import Optional, Dict, List, Any
 
 @mcp.tool()
-def mysql_get_tables(host:str, user:str, password:str, database:str) -> Optional[List[str]] :
+def mysql_get_tables(host:str, user:str, password:str, database:str, port:int = 3307) -> Optional[List[str]] :
     """
     Retrieves the list of table names in a MySQL database.
 
@@ -16,14 +16,15 @@ def mysql_get_tables(host:str, user:str, password:str, database:str) -> Optional
         user (str): The username to authenticate with.
         password (str): The password for the MySQL user.
         database (str): The name of the database to fetch tables from.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[List[str]]: A list of table names if successful, otherwise None.
     """
-    return get_tables(host=host, user=user, password=password, database=database)
+    return get_tables(host=host, user=user, password=password, database=database, port=port)
 
 @mcp.tool()
-def mysql_get_schema(host:str, user:str, password:str, database:str) -> Optional[Dict[str, list]] :
+def mysql_get_schema(host:str, user:str, password:str, database:str, port:int = 3307) -> Optional[Dict[str, list]] :
     """
     Retrieves the schema of a given MySQL database as a dictionary.
 
@@ -32,15 +33,16 @@ def mysql_get_schema(host:str, user:str, password:str, database:str) -> Optional
         user (str): The username to authenticate with.
         password (str): The password for the MySQL user.
         database (str): The name of the database to retrieve the schema from.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[Dict[str, list]]: A dictionary where keys are table names and values are lists of column definitions.
         Returns None if the connection or table retrieval fails.
     """
-    return get_schema(host=host, user=user, password=password, database=database)
+    return get_schema(host=host, user=user, password=password, database=database, port=port)
 
 @mcp.tool()
-def mysql_get_table_description(host:str, user:str, password:str, database:str, table_name:str) -> Optional[Dict[str, list]] :
+def mysql_get_table_description(host:str, user:str, password:str, database:str, table_name:str, port:int = 3307) -> Optional[Dict[str, list]] :
     """
     Retrieves the schema of a specific table from a given MySQL database.
 
@@ -50,15 +52,16 @@ def mysql_get_table_description(host:str, user:str, password:str, database:str, 
         password (str): The password for the MySQL user.
         database (str): The name of the database containing the table.
         table_name (str): The name of the table to retrieve the schema from.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[Dict[str, list]]: A dictionary where the key is the table name and the value is a list of column definitions.
         Returns None if the connection or schema retrieval fails.
     """
-    return get_table_description(host=host, user=user, password=password, database=database, table_name=table_name)
+    return get_table_description(host=host, user=user, password=password, database=database, table_name=table_name, port=port)
 
 @mcp.tool()
-def mysql_get_all_rows(host:str, user:str, password:str, database:str, table_name:str) -> Optional[List[Dict]]:
+def mysql_get_all_rows(host:str, user:str, password:str, database:str, table_name:str, port:int = 3307) -> Optional[List[Dict]]:
     """
     Retrieves all rows from the specified table in the given database.
 
@@ -68,15 +71,16 @@ def mysql_get_all_rows(host:str, user:str, password:str, database:str, table_nam
         password (str): The database password.
         database (str): The name of the database.
         table_name (str): The name of the table to fetch data from.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[List[Dict]]: A list of dictionaries where each dictionary represents a row from the table.
         Returns None if an error occurs or the table is empty.
     """
-    return get_all_rows(host=host, user=user, password=password, database=database, table_name=table_name)
+    return get_all_rows(host=host, user=user, password=password, database=database, table_name=table_name, port=port)
 
 @mcp.tool()
-def mysql_get_filtered_rows(host: str, user: str, password: str, database: str, table_name: str, filters: Dict[str, Any]) -> Optional[List[Dict]]:
+def mysql_get_filtered_rows(host: str, user: str, password: str, database: str, table_name: str, filters: Dict[str, Any], port: int = 3307) -> Optional[List[Dict]]:
     """
     Retrieves rows from the specified table in the given database based on filter criteria.
 
@@ -87,15 +91,16 @@ def mysql_get_filtered_rows(host: str, user: str, password: str, database: str, 
         database (str): The name of the database.
         table_name (str): The name of the table to fetch data from.
         filters (Dict[str, Any]): A dictionary where keys are column names and values are the filtering criteria.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[List[Dict]]: A list of dictionaries where each dictionary represents a row from the table.
         Returns None if an error occurs or no data matches the filters.
     """
-    return get_filtered_rows(host, user, password, database, table_name, filters)
+    return get_filtered_rows(host, user, password, database, table_name, filters, port=port)
 
 @mcp.tool()
-def mysql_get_sorted_rows(host: str, user: str, password: str, database: str, table_name: str, sort_by: str, order: str = 'ASC')  -> Optional[List[Dict]]:
+def mysql_get_sorted_rows(host: str, user: str, password: str, database: str, table_name: str, sort_by: str, order: str = 'ASC', port: int = 3307)  -> Optional[List[Dict]]:
     """
     Retrieves sorted rows from the specified table.
 
@@ -107,14 +112,15 @@ def mysql_get_sorted_rows(host: str, user: str, password: str, database: str, ta
         table_name (str): The table name.
         sort_by (str): The column to sort by.
         order (str): The sort order ('ASC' or 'DESC'). Default is 'ASC'.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[List[Dict]]: Sorted rows as a list of dictionaries, or None on error.
     """
-    return get_sorted_rows(host, user, password, database, table_name, sort_by, order)
+    return get_sorted_rows(host, user, password, database, table_name, sort_by, order, port=port)
 
 @mcp.tool()
-def mysql_get_limited_rows(host: str, user: str, password: str, database: str, table_name: str, limit: int, offset: int = 0)  -> Optional[List[Dict]]:
+def mysql_get_limited_rows(host: str, user: str, password: str, database: str, table_name: str, limit: int, offset: int = 0, port: int = 3307)  -> Optional[List[Dict]]:
     """
     Retrieves a limited number of rows from the specified table.
 
@@ -126,14 +132,15 @@ def mysql_get_limited_rows(host: str, user: str, password: str, database: str, t
         table_name (str): The table name.
         limit (int): The number of rows to fetch.
         offset (int): The starting point for fetching rows. Default is 0.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[List[Dict]]: Limited rows as a list of dictionaries, or None on error.
     """
-    return get_limited_rows(host, user, password, database, table_name, limit, offset)
+    return get_limited_rows(host, user, password, database, table_name, limit, offset, port=port)
 
 @mcp.tool()
-def mysql_get_distinct_values(host: str, user: str, password: str, database: str, table_name: str, column: str) -> Optional[List[Any]]:
+def mysql_get_distinct_values(host: str, user: str, password: str, database: str, table_name: str, column: str, port: int = 3307) -> Optional[List[Any]]:
     """
     Retrieves distinct values from a specific column in the given table.
 
@@ -144,28 +151,30 @@ def mysql_get_distinct_values(host: str, user: str, password: str, database: str
         database (str): The database name.
         table_name (str): The table name.
         column (str): The column name.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[List[Any]]: A list of distinct values or None on error.
     """
-    return get_distinct_values(host, user, password, database, table_name, column)
+    return get_distinct_values(host, user, password, database, table_name, column, port=port)
 
 @mcp.tool()
-def mysql_get_aggregated_data(host: str, user: str, password: str, database: str, table_name: str, aggregation: str, column: str) -> Optional[Any]:
+def mysql_get_aggregated_data(host: str, user: str, password: str, database: str, table_name: str, aggregation: str, column: str, port: int = 3307) -> Optional[Any]:
     """
     Retrieves aggregated data from a specified column in the given table.
 
     Args:
         aggregation (str): The aggregation function (e.g., COUNT, SUM, AVG).
         column (str): The column name.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[Any]: The result of the aggregation or None on error.
     """
-    return get_aggregated_data(host, user, password, database, table_name, aggregation, column)
+    return get_aggregated_data(host, user, password, database, table_name, aggregation, column, port=port)
 
 @mcp.tool()
-def mysql_get_grouped_data(host: str, user: str, password: str, database: str, table_name: str, group_by: str, aggregation: str, column: str) -> Optional[Dict[str, Any]]:
+def mysql_get_grouped_data(host: str, user: str, password: str, database: str, table_name: str, group_by: str, aggregation: str, column: str, port: int = 3307) -> Optional[Dict[str, Any]]:
     """
     Groups data by a specified column and applies an aggregation function.
 
@@ -178,15 +187,16 @@ def mysql_get_grouped_data(host: str, user: str, password: str, database: str, t
         group_by (str): The column to group by.
         aggregation (str): The aggregation function (e.g., SUM, AVG).
         column (str): The column to aggregate.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[Dict[str, Any]]: A dictionary where keys are group values and values are aggregated data,
         or None if an error occurs.
     """
-    return get_grouped_data(host, user, password, database, table_name, group_by, aggregation, column)
+    return get_grouped_data(host, user, password, database, table_name, group_by, aggregation, column, port=port)
 
 @mcp.tool()
-def mysql_create_table(host:str, user:str, password:str, database:str, table_name:str, columns: Dict[str, str], options: Optional[Dict[str, str]] = None) -> bool:
+def mysql_create_table(host:str, user:str, password:str, database:str, table_name:str, columns: Dict[str, str], options: Optional[Dict[str, str]] = None, port: int = 3307) -> bool:
     """
     Creates a table with the specified columns and options.
     Args:
@@ -197,13 +207,14 @@ def mysql_create_table(host:str, user:str, password:str, database:str, table_nam
         table_name (str): The name of the table to create.
         columns (Dict[str, str]): A dictionary of column names and their data types.
         options (Optional[Dict[str, str]]): Additional options like PRIMARY KEY, AUTO_INCREMENT, UNIQUE, NOT NULL.
+        port (int): The port number for the MySQL server.
     Returns:
         bool: True if the table was created successfully, False otherwise.
     """
-    return create_table(host, user, password, database, table_name, columns, options)
+    return create_table(host, user, password, database, table_name, columns, options, port=port)
 
 @mcp.tool()
-def mysql_drop_table(host: str, user: str, password: str, database: str, table_name: str) -> bool:
+def mysql_drop_table(host: str, user: str, password: str, database: str, table_name: str, port: int = 3307) -> bool:
     """
     Drops the specified table.
     Args:
@@ -212,13 +223,14 @@ def mysql_drop_table(host: str, user: str, password: str, database: str, table_n
         password (str): The database password.
         database (str): The database name.
         table_name (str): The name of the table to drop.
+        port (int): The port number for the MySQL server.
     Returns:
         bool: True if the table was dropped successfully, False otherwise.
     """
-    return drop_table(host, user, password, database, table_name)
+    return drop_table(host, user, password, database, table_name, port=port)
 
 @mcp.tool()
-def mysql_show_indexes(host: str, user: str, password: str, database: str, table_name: str) -> Optional[List[Dict[str, str]]]:
+def mysql_show_indexes(host: str, user: str, password: str, database: str, table_name: str, port: int = 3307) -> Optional[List[Dict[str, str]]]:
     """
     Retrieves all indexes from a given table.
     Args:
@@ -227,13 +239,14 @@ def mysql_show_indexes(host: str, user: str, password: str, database: str, table
         password (str): The database password.
         database (str): The database name.
         table_name (str): The name of the table to retrieve indexes from.
+        port (int): The port number for the MySQL server.
     Returns:
         Optional[List[Dict[str, str]]]: A list of dictionaries containing index information, or None if an error occurs.
     """
-    return show_indexes(host, user, password, database, table_name)
+    return show_indexes(host, user, password, database, table_name, port=port)
 
 @mcp.tool()
-def mysql_create_index(host: str, user: str, password: str, database: str, table_name: str, index_name: str, columns: List[str], unique: bool = False) -> bool:
+def mysql_create_index(host: str, user: str, password: str, database: str, table_name: str, index_name: str, columns: List[str], unique: bool = False, port: int = 3307) -> bool:
     """
     Creates an index on the specified columns of a table.
     Args:
@@ -245,13 +258,14 @@ def mysql_create_index(host: str, user: str, password: str, database: str, table
         index_name (str): The name of the index.
         columns (List[str]): A list of column names to be indexed.
         unique (bool): If True, creates a UNIQUE index. Defaults to False.
+        port (int): The port number for the MySQL server.
     Returns:
         bool: True if the index was created successfully, False otherwise.
     """
-    return create_index(host, user, password, database, table_name, index_name, columns, unique)
+    return create_index(host, user, password, database, table_name, index_name, columns, unique, port=port)
 
 @mcp.tool()
-def mysql_insert_row(host:str, user:str, password:str, database:str, table_name:str, data:Dict[str, Any]) -> bool :
+def mysql_insert_row(host:str, user:str, password:str, database:str, table_name:str, data:Dict[str, Any], port: int = 3307) -> bool :
     """
     Inserts a single row into the specified table.
 
@@ -262,14 +276,15 @@ def mysql_insert_row(host:str, user:str, password:str, database:str, table_name:
         database (str): The database name.
         table_name (str): The name of the table to insert into.
         data (Dict[str, Any]): A dictionary containing column names and their values.
+        port (int): The port number for the MySQL server.
 
     Returns:
         bool: True if the insertion was successful, False otherwise.
     """
-    return insert_row(host, user, password, database, table_name, data)
+    return insert_row(host, user, password, database, table_name, data, port=port)
 
 @mcp.tool()
-def mysql_insert_multiple_rows(host: str, user: str, password: str, database: str, table_name: str, data: List[Dict[str, Any]]) -> bool:
+def mysql_insert_multiple_rows(host: str, user: str, password: str, database: str, table_name: str, data: List[Dict[str, Any]], port: int = 3307) -> bool:
     """
     Inserts multiple rows into the specified table.
 
@@ -280,14 +295,15 @@ def mysql_insert_multiple_rows(host: str, user: str, password: str, database: st
         database (str): The database name.
         table_name (str): The name of the table to insert into.
         data (List[Dict[str, Any]]): A list of dictionaries, each representing a row to insert.
+        port (int): The port number for the MySQL server.
 
     Returns:
         bool: True if the insertion was successful, False otherwise.
     """
-    return insert_multiple_rows(host, user, password, database, table_name, data)
+    return insert_multiple_rows(host, user, password, database, table_name, data, port=port)
 
 @mcp.tool()
-def mysql_delete_rows(host: str, user: str, password: str, database: str, table_name: str, conditions: Dict[str, Any]) -> bool:
+def mysql_delete_rows(host: str, user: str, password: str, database: str, table_name: str, conditions: Dict[str, Any], port: int = 3307) -> bool:
     """
     Deletes rows from the specified table based on conditions.
 
@@ -298,14 +314,15 @@ def mysql_delete_rows(host: str, user: str, password: str, database: str, table_
         database (str): The database name.
         table_name (str): The name of the table to delete from.
         conditions (Dict[str, Any]): A dictionary containing conditions to match for deletion.
+        port (int): The port number for the MySQL server.
 
     Returns:
         bool: True if the deletion was successful, False otherwise.
     """
-    return delete_rows(host, user, password, database, table_name, conditions)
+    return delete_rows(host, user, password, database, table_name, conditions, port=port)
 
 @mcp.tool()
-def mysql_update_rows(host: str, user: str, password: str, database: str, table_name: str, data: Dict[str, Any], conditions: Dict[str, Any]) -> bool:
+def mysql_update_rows(host: str, user: str, password: str, database: str, table_name: str, data: Dict[str, Any], conditions: Dict[str, Any], port: int = 3307) -> bool:
     """
     Updates rows in the specified table based on conditions.
 
@@ -317,14 +334,15 @@ def mysql_update_rows(host: str, user: str, password: str, database: str, table_
         table_name (str): The name of the table to update.
         data (Dict[str, Any]): A dictionary containing columns and their new values.
         conditions (Dict[str, Any]): A dictionary containing conditions to match for updating.
+        port (int): The port number for the MySQL server.
 
     Returns:
         bool: True if the update was successful, False otherwise.
     """
-    return update_rows(host, user, password, database, table_name, data, conditions)
+    return update_rows(host, user, password, database, table_name, data, conditions, port=port)
 
 @mcp.tool()
-def mysql_execute_custom_query(host: str, user: str, password: str, database: str, query: str) -> Optional[List[Dict]]:
+def mysql_execute_custom_query(host: str, user: str, password: str, database: str, query: str, port: int = 3307) -> Optional[List[Dict]]:
     """
     Executes a custom SQL query and returns the result as a list of dictionaries. Only use this if necessary like for complex queries. Reply on built in methods to execute queries.
 
@@ -334,8 +352,9 @@ def mysql_execute_custom_query(host: str, user: str, password: str, database: st
         password (str): The database password.
         database (str): The database name.
         query (str): The SQL query to execute.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[List[Dict]]: The result of the query as a list of dictionaries, or None if an error occurs.
     """
-    return execute_custom_query(host, user, password, database, query)
+    return execute_custom_query(host, user, password, database, query, port=port)

--- a/mysqldb/services/connection.py
+++ b/mysqldb/services/connection.py
@@ -5,7 +5,7 @@ from typing import Optional
 # Set up logger for this module
 logger = LoggerFactory.get_logger(__name__)
 
-def connect_to_mysql(host:str, user:str, password:str, database:str) -> Optional[MySQLConnection]:
+def connect_to_mysql(host:str, user:str, password:str, database:str, port:int = 3306) -> Optional[MySQLConnection]:
     """
     Establishes a connection to a MySQL database.
 
@@ -14,6 +14,7 @@ def connect_to_mysql(host:str, user:str, password:str, database:str) -> Optional
         user (str): The username to authenticate with.
         password (str): The password for the MySQL user.
         database (str): The name of the database to connect to.
+        port (int): The port number of the MySQL server. Defaults to 3306.
 
     Returns:
         Optional[MySQLConnection]: A MySQLConnection object if the connection is successful, otherwise None.
@@ -21,16 +22,17 @@ def connect_to_mysql(host:str, user:str, password:str, database:str) -> Optional
     try:
         connection = connect(
             host=host,
-            user=user, 
-            password=password, 
-            database=database
+            user=user,
+            password=password,
+            database=database,
+            port=port
         )
         if connection.is_connected():
-            logger.info(f"Successfully connected to MySQL database '{database}' as user '{user}'")
+            logger.info(f"Successfully connected to MySQL database '{database}' on port {port} as user '{user}'")
             return connection
         else:
-            logger.error(f"Failed to connect to MySQL database '{database}'")
+            logger.error(f"Failed to connect to MySQL database '{database}' on port {port}")
             return None
     except Error as e:
-        logger.error(f"Error while connecting to MySQL database '{database}': {str(e)}")
+        logger.error(f"Error while connecting to MySQL database '{database}' on port {port}: {str(e)}")
         return None

--- a/mysqldb/services/reads.py
+++ b/mysqldb/services/reads.py
@@ -8,7 +8,7 @@ from mysql.connector import Error
 
 logger = LoggerFactory.get_logger(__name__)
 
-def get_all_rows(host: str, user: str, password: str, database: str, table_name: str, port: int = 3307) -> Optional[List[Dict]]:
+def get_all_rows(host: str, user: str, password: str, database: str, table_name: str, port: int = 3306) -> Optional[List[Dict]]:
     """
     Retrieves all rows from the specified table in the given database.
     """
@@ -33,7 +33,7 @@ def get_all_rows(host: str, user: str, password: str, database: str, table_name:
             connection.close()
 
 def get_filtered_rows(
-    host: str, user: str, password: str, database: str, table_name: str, filters: Dict[str, Any], port: int = 3307
+    host: str, user: str, password: str, database: str, table_name: str, filters: Dict[str, Any], port: int = 3306
 ) -> Optional[List[Dict]]:
     """
     Retrieves rows from the specified table in the given database based on filter criteria.
@@ -62,7 +62,7 @@ def get_filtered_rows(
             connection.close()
 
 def get_sorted_rows(
-    host: str, user: str, password: str, database: str, table_name: str, sort_by: str, order: str = 'ASC', port: int = 3307
+    host: str, user: str, password: str, database: str, table_name: str, sort_by: str, order: str = 'ASC', port: int = 3306
 ) -> Optional[List[Dict]]:
     """
     Retrieves sorted rows from the specified table.
@@ -88,7 +88,7 @@ def get_sorted_rows(
             connection.close()
 
 def get_limited_rows(
-    host: str, user: str, password: str, database: str, table_name: str, limit: int, offset: int = 0, port: int = 3307
+    host: str, user: str, password: str, database: str, table_name: str, limit: int, offset: int = 0, port: int = 3306
 ) -> Optional[List[Dict]]:
     """
     Retrieves a limited number of rows from the specified table.
@@ -114,7 +114,7 @@ def get_limited_rows(
             connection.close()
 
 def get_distinct_values(
-    host: str, user: str, password: str, database: str, table_name: str, column: str, port: int = 3307
+    host: str, user: str, password: str, database: str, table_name: str, column: str, port: int = 3306
 ) -> Optional[List[Any]]:
     """
     Retrieves distinct values from a specific column in the given table.
@@ -140,7 +140,7 @@ def get_distinct_values(
             connection.close()
 
 def get_aggregated_data(
-    host: str, user: str, password: str, database: str, table_name: str, aggregation: str, column: str, port: int = 3307
+    host: str, user: str, password: str, database: str, table_name: str, aggregation: str, column: str, port: int = 3306
 ) -> Optional[Any]:
     """
     Retrieves aggregated data from a specified column in the given table.
@@ -166,7 +166,7 @@ def get_aggregated_data(
             connection.close()
 
 def get_grouped_data(
-    host: str, user: str, password: str, database: str, table_name: str, group_by: str, aggregation: str, column: str, port: int = 3307
+    host: str, user: str, password: str, database: str, table_name: str, group_by: str, aggregation: str, column: str, port: int = 3306
 ) -> Optional[Dict[str, Any]]:
     """
     Groups data by a specified column and applies an aggregation function.
@@ -191,7 +191,7 @@ def get_grouped_data(
         if connection:
             connection.close()
 
-def execute_custom_query(host: str, user: str, password: str, database: str, query: str, port: int = 3307) -> Optional[List[Dict]]:
+def execute_custom_query(host: str, user: str, password: str, database: str, query: str, port: int = 3306) -> Optional[List[Dict]]:
     """
     Executes a custom SQL query and returns the result as a list of dictionaries.
     """

--- a/mysqldb/services/reads.py
+++ b/mysqldb/services/reads.py
@@ -8,330 +8,209 @@ from mysql.connector import Error
 
 logger = LoggerFactory.get_logger(__name__)
 
-def get_all_rows(host: str, user: str, password: str, database: str, table_name: str) -> Optional[List[Dict]]:
+def get_all_rows(host: str, user: str, password: str, database: str, table_name: str, port: int = 3307) -> Optional[List[Dict]]:
     """
     Retrieves all rows from the specified table in the given database.
-
-    Args:
-        host (str): The database host.
-        user (str): The database user.
-        password (str): The database password.
-        database (str): The name of the database.
-        table_name (str): The name of the table to fetch data from.
-
-    Returns:
-        Optional[List[Dict]]: A list of dictionaries where each dictionary represents a row from the table.
-        Returns None if an error occurs or the table is empty.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host=host, user=user, password=password, database=database)
+        connection: MySQLConnection = connect_to_mysql(host=host, user=user, password=password, database=database, port=port)
         if not connection:
-            logger.error(f"Failed to connect to database: '{database}'")
             return None
-
         cursor: MySQLCursor = connection.cursor(dictionary=True)
-        
         query = f"SELECT * FROM {table_name};"
-        logger.info(f"Executing query: {query}")
         cursor.execute(query)
-        
         rows: List[Dict] = cursor.fetchall()
-        if not rows:
-            logger.warning(f"No data found in table '{table_name}'")
-            return []
-
-        logger.info(f"Successfully fetched {len(rows)} rows from '{table_name}'")
         return rows
-
     except Error as e:
         logger.error(f"Error occurred while fetching data from '{table_name}': {str(e)}")
         return None
-
     finally:
-        try:
-            if cursor:
-                cursor.close()
-            if connection:
-                connection.close()
-            logger.info("Database connection closed.")
-        except Exception as ex:
-            logger.error(f"Error while closing resources: {str(ex)}")
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
 
 def get_filtered_rows(
-    host: str, user: str, password: str, database: str, table_name: str, filters: Dict[str, Any]
+    host: str, user: str, password: str, database: str, table_name: str, filters: Dict[str, Any], port: int = 3307
 ) -> Optional[List[Dict]]:
     """
     Retrieves rows from the specified table in the given database based on filter criteria.
-
-    Args:
-        host (str): The database host.
-        user (str): The database user.
-        password (str): The database password.
-        database (str): The name of the database.
-        table_name (str): The name of the table to fetch data from.
-        filters (Dict[str, Any]): A dictionary where keys are column names and values are the filtering criteria.
-
-    Returns:
-        Optional[List[Dict]]: A list of dictionaries where each dictionary represents a row from the table.
-        Returns None if an error occurs or no data matches the filters.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host=host, user=user, password=password, database=database)
+        connection: MySQLConnection = connect_to_mysql(host=host, user=user, password=password, database=database, port=port)
         if not connection:
-            logger.error(f"Failed to connect to database: '{database}'")
             return None
-
         cursor: MySQLCursor = connection.cursor(dictionary=True)
-
         where_clauses = [f"`{key}` = %s" for key in filters.keys()]
         where_statement = " AND ".join(where_clauses)
-
         query = f"SELECT * FROM {table_name} WHERE {where_statement};"
         values = list(filters.values())
-        logger.info(f"Executing query: {query} with values {values}")
-
         cursor.execute(query, values)
-
         rows: List[Dict] = cursor.fetchall()
-        if not rows:
-            logger.warning(f"No data found in table '{table_name}' with filters: {filters}")
-            return []
-
-        logger.info(f"Successfully fetched {len(rows)} rows from '{table_name}'")
         return rows
-
     except Error as e:
         logger.error(f"Error occurred while fetching filtered data from '{table_name}': {str(e)}")
         return None
-
     finally:
-        try:
-            if cursor:
-                cursor.close()
-            if connection:
-                connection.close()
-            logger.info("Database connection closed.")
-        except Exception as ex:
-            logger.error(f"Error while closing resources: {str(ex)}")
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
 
 def get_sorted_rows(
-    host: str, user: str, password: str, database: str, table_name: str, sort_by: str, order: str = 'ASC'
+    host: str, user: str, password: str, database: str, table_name: str, sort_by: str, order: str = 'ASC', port: int = 3307
 ) -> Optional[List[Dict]]:
     """
     Retrieves sorted rows from the specified table.
-
-    Args:
-        host (str): The database host.
-        user (str): The database user.
-        password (str): The database password.
-        database (str): The database name.
-        table_name (str): The table name.
-        sort_by (str): The column to sort by.
-        order (str): The sort order ('ASC' or 'DESC'). Default is 'ASC'.
-
-    Returns:
-        Optional[List[Dict]]: Sorted rows as a list of dictionaries, or None on error.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host, user, password, database)
+        connection: MySQLConnection = connect_to_mysql(host, user, password, database, port=port)
         if not connection:
-            logger.error(f"Failed to connect to database: '{database}'")
             return None
-
         cursor: MySQLCursor = connection.cursor(dictionary=True)
-
         query = f"SELECT * FROM {table_name} ORDER BY `{sort_by}` {order};"
-        logger.info(f"Executing query: {query}")
-
         cursor.execute(query)
         rows = cursor.fetchall()
         return rows
-
     except Error as e:
         logger.error(f"Error fetching sorted rows from '{table_name}': {str(e)}")
         return None
-
     finally:
-        cursor.close()
-        connection.close()
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
 
 def get_limited_rows(
-    host: str, user: str, password: str, database: str, table_name: str, limit: int, offset: int = 0
+    host: str, user: str, password: str, database: str, table_name: str, limit: int, offset: int = 0, port: int = 3307
 ) -> Optional[List[Dict]]:
     """
     Retrieves a limited number of rows from the specified table.
-
-    Args:
-        host (str): The database host.
-        user (str): The database user.
-        password (str): The database password.
-        database (str): The database name.
-        table_name (str): The table name.
-        limit (int): The number of rows to fetch.
-        offset (int): The starting point for fetching rows. Default is 0.
-
-    Returns:
-        Optional[List[Dict]]: Limited rows as a list of dictionaries, or None on error.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host, user, password, database)
+        connection: MySQLConnection = connect_to_mysql(host, user, password, database, port=port)
         if not connection:
-            logger.error(f"Failed to connect to database: '{database}'")
             return None
-
         cursor: MySQLCursor = connection.cursor(dictionary=True)
-
         query = f"SELECT * FROM {table_name} LIMIT %s OFFSET %s;"
-        logger.info(f"Executing query: {query}")
-
         cursor.execute(query, (limit, offset))
         rows = cursor.fetchall()
         return rows
-
     except Error as e:
         logger.error(f"Error fetching limited rows from '{table_name}': {str(e)}")
         return None
-
     finally:
-        cursor.close()
-        connection.close()
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
 
 def get_distinct_values(
-    host: str, user: str, password: str, database: str, table_name: str, column: str
+    host: str, user: str, password: str, database: str, table_name: str, column: str, port: int = 3307
 ) -> Optional[List[Any]]:
     """
     Retrieves distinct values from a specific column in the given table.
-
-    Args:
-        host (str): The database host.
-        user (str): The database user.
-        password (str): The database password.
-        database (str): The database name.
-        table_name (str): The table name.
-        column (str): The column name.
-
-    Returns:
-        Optional[List[Any]]: A list of distinct values or None on error.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host, user, password, database)
+        connection: MySQLConnection = connect_to_mysql(host, user, password, database, port=port)
         if not connection:
-            logger.error(f"Failed to connect to database: '{database}'")
             return None
-
         cursor: MySQLCursor = connection.cursor()
-
         query = f"SELECT DISTINCT `{column}` FROM {table_name};"
-        logger.info(f"Executing query: {query}")
-
         cursor.execute(query)
         values = [row[0] for row in cursor.fetchall()]
         return values
-
     except Error as e:
         logger.error(f"Error fetching distinct values from '{table_name}': {str(e)}")
         return None
-
     finally:
-        cursor.close()
-        connection.close()
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
 
 def get_aggregated_data(
-    host: str, user: str, password: str, database: str, table_name: str, aggregation: str, column: str
+    host: str, user: str, password: str, database: str, table_name: str, aggregation: str, column: str, port: int = 3307
 ) -> Optional[Any]:
     """
     Retrieves aggregated data from a specified column in the given table.
-
-    Args:
-        aggregation (str): The aggregation function (e.g., COUNT, SUM, AVG).
-        column (str): The column name.
-
-    Returns:
-        Optional[Any]: The result of the aggregation or None on error.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host, user, password, database)
+        connection: MySQLConnection = connect_to_mysql(host, user, password, database, port=port)
+        if not connection:
+            return None
         cursor: MySQLCursor = connection.cursor()
-
         query = f"SELECT {aggregation}(`{column}`) FROM {table_name};"
-        logger.info(f"Executing query: {query}")
-
         cursor.execute(query)
         result = cursor.fetchone()
         return result[0] if result else None
-
     except Error as e:
         logger.error(f"Error in aggregation on '{table_name}': {str(e)}")
         return None
-
     finally:
-        cursor.close()
-        connection.close()
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
 
 def get_grouped_data(
-    host: str, user: str, password: str, database: str, table_name: str, group_by: str, aggregation: str, column: str
+    host: str, user: str, password: str, database: str, table_name: str, group_by: str, aggregation: str, column: str, port: int = 3307
 ) -> Optional[Dict[str, Any]]:
     """
     Groups data by a specified column and applies an aggregation function.
-
-    Args:
-        host (str): The database host.
-        user (str): The database user.
-        password (str): The database password.
-        database (str): The database name.
-        table_name (str): The name of the table to query.
-        group_by (str): The column to group by.
-        aggregation (str): The aggregation function (e.g., SUM, AVG).
-        column (str): The column to aggregate.
-
-    Returns:
-        Optional[Dict[str, Any]]: A dictionary where keys are group values and values are aggregated data,
-        or None if an error occurs.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host, user, password, database)
+        connection: MySQLConnection = connect_to_mysql(host, user, password, database, port=port)
+        if not connection:
+            return None
         cursor: MySQLCursor = connection.cursor(dictionary=True)
-
         query = f"SELECT `{group_by}`, {aggregation}(`{column}`) AS aggregate FROM {table_name} GROUP BY `{group_by}`;"
-        logger.info(f"Executing query: {query}")
-
         cursor.execute(query)
         results = cursor.fetchall()
-        cursor.close()
-        connection.close()
         return {row[group_by]: row['aggregate'] for row in results}
-
     except Error as e:
         logger.error(f"Error fetching grouped data from '{table_name}': {str(e)}")
         return None
+    finally:
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
 
-def execute_custom_query(host: str, user: str, password: str, database: str, query: str) -> Optional[List[Dict]]:
+def execute_custom_query(host: str, user: str, password: str, database: str, query: str, port: int = 3307) -> Optional[List[Dict]]:
     """
     Executes a custom SQL query and returns the result as a list of dictionaries.
-
-    Args:
-        host (str): The database host.
-        user (str): The database user.
-        password (str): The database password.
-        database (str): The database name.
-        query (str): The SQL query to execute.
-
-    Returns:
-        Optional[List[Dict]]: The result of the query as a list of dictionaries, or None if an error occurs.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host, user, password, database)
+        connection: MySQLConnection = connect_to_mysql(host, user, password, database, port=port)
+        if not connection:
+            return None
         cursor: MySQLCursor = connection.cursor(dictionary=True)
-
         logger.info(f"Executing custom query: {query}")
         cursor.execute(query)
         rows = cursor.fetchall()
         return rows
-
     except Error as e:
         logger.error(f"Error executing custom query: {str(e)}")
         return None
-
     finally:
-        cursor.close()
-        connection.close()
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()

--- a/mysqldb/services/reads.py
+++ b/mysqldb/services/reads.py
@@ -11,6 +11,18 @@ logger = LoggerFactory.get_logger(__name__)
 def get_all_rows(host: str, user: str, password: str, database: str, table_name: str, port: int = 3306) -> Optional[List[Dict]]:
     """
     Retrieves all rows from the specified table in the given database.
+
+    Args:
+        host (str): The database host.
+        user (str): The database user.
+        password (str): The database password.
+        database (str): The name of the database.
+        table_name (str): The name of the table to fetch data from.
+        port (int): The port number for the MySQL server.
+
+    Returns:
+        Optional[List[Dict]]: A list of dictionaries where each dictionary represents a row from the table.
+        Returns None if an error occurs or the table is empty.
     """
     connection = None
     cursor = None
@@ -53,6 +65,19 @@ def get_filtered_rows(
 ) -> Optional[List[Dict]]:
     """
     Retrieves rows from the specified table in the given database based on filter criteria.
+
+    Args:
+        host (str): The database host.
+        user (str): The database user.
+        password (str): The database password.
+        database (str): The name of the database.
+        table_name (str): The name of the table to fetch data from.
+        filters (Dict[str, Any]): A dictionary where keys are column names and values are the filtering criteria.
+        port (int): The port number for the MySQL server.
+
+    Returns:
+        Optional[List[Dict]]: A list of dictionaries where each dictionary represents a row from the table.
+        Returns None if an error occurs or no data matches the filters.
     """
     connection = None
     cursor = None
@@ -100,6 +125,19 @@ def get_sorted_rows(
 ) -> Optional[List[Dict]]:
     """
     Retrieves sorted rows from the specified table.
+
+    Args:
+        host (str): The database host.
+        user (str): The database user.
+        password (str): The database password.
+        database (str): The database name.
+        table_name (str): The table name.
+        sort_by (str): The column to sort by.
+        order (str): The sort order ('ASC' or 'DESC'). Default is 'ASC'.
+        port (int): The port number for the MySQL server.
+
+    Returns:
+        Optional[List[Dict]]: Sorted rows as a list of dictionaries, or None on error.
     """
     connection = None
     cursor = None
@@ -133,6 +171,19 @@ def get_limited_rows(
 ) -> Optional[List[Dict]]:
     """
     Retrieves a limited number of rows from the specified table.
+
+    Args:
+        host (str): The database host.
+        user (str): The database user.
+        password (str): The database password.
+        database (str): The database name.
+        table_name (str): The table name.
+        limit (int): The number of rows to fetch.
+        offset (int): The starting point for fetching rows. Default is 0.
+        port (int): The port number for the MySQL server.
+
+    Returns:
+        Optional[List[Dict]]: Limited rows as a list of dictionaries, or None on error.
     """
     connection = None
     cursor = None
@@ -166,6 +217,18 @@ def get_distinct_values(
 ) -> Optional[List[Any]]:
     """
     Retrieves distinct values from a specific column in the given table.
+
+    Args:
+        host (str): The database host.
+        user (str): The database user.
+        password (str): The database password.
+        database (str): The database name.
+        table_name (str): The table name.
+        column (str): The column name.
+        port (int): The port number for the MySQL server.
+
+    Returns:
+        Optional[List[Any]]: A list of distinct values or None on error.
     """
     connection = None
     cursor = None
@@ -199,11 +262,21 @@ def get_aggregated_data(
 ) -> Optional[Any]:
     """
     Retrieves aggregated data from a specified column in the given table.
+
+    Args:
+        aggregation (str): The aggregation function (e.g., COUNT, SUM, AVG).
+        column (str): The column name.
+        port (int): The port number for the MySQL server.
+
+    Returns:
+        Optional[Any]: The result of the aggregation or None on error.
     """
     connection = None
     cursor = None
     try:
         connection: MySQLConnection = connect_to_mysql(host, user, password, database, port=port)
+        if not connection:
+            return None
         cursor: MySQLCursor = connection.cursor()
 
         query = f"SELECT {aggregation}(`{column}`) FROM {table_name};"
@@ -228,11 +301,28 @@ def get_grouped_data(
 ) -> Optional[Dict[str, Any]]:
     """
     Groups data by a specified column and applies an aggregation function.
+
+    Args:
+        host (str): The database host.
+        user (str): The database user.
+        password (str): The database password.
+        database (str): The database name.
+        table_name (str): The name of the table to query.
+        group_by (str): The column to group by.
+        aggregation (str): The aggregation function (e.g., SUM, AVG).
+        column (str): The column to aggregate.
+        port (int): The port number for the MySQL server.
+
+    Returns:
+        Optional[Dict[str, Any]]: A dictionary where keys are group values and values are aggregated data,
+        or None if an error occurs.
     """
     connection = None
     cursor = None
     try:
         connection: MySQLConnection = connect_to_mysql(host, user, password, database, port=port)
+        if not connection:
+            return None
         cursor: MySQLCursor = connection.cursor(dictionary=True)
 
         query = f"SELECT `{group_by}`, {aggregation}(`{column}`) AS aggregate FROM {table_name} GROUP BY `{group_by}`;"
@@ -254,6 +344,17 @@ def get_grouped_data(
 def execute_custom_query(host: str, user: str, password: str, database: str, query: str, port: int = 3306) -> Optional[List[Dict]]:
     """
     Executes a custom SQL query and returns the result as a list of dictionaries.
+
+    Args:
+        host (str): The database host.
+        user (str): The database user.
+        password (str): The database password.
+        database (str): The database name.
+        query (str): The SQL query to execute.
+        port (int): The port number for the MySQL server.
+
+    Returns:
+        Optional[List[Dict]]: The result of the query as a list of dictionaries, or None if an error occurs.
     """
     connection = None
     cursor = None

--- a/mysqldb/services/schema.py
+++ b/mysqldb/services/schema.py
@@ -10,7 +10,7 @@ from mysql.connector import MySQLConnection
 
 logger = LoggerFactory.get_logger(__name__)
 
-def get_tables(host:str, user:str, password:str, database:str) -> Optional[List[str]]:
+def get_tables(host:str, user:str, password:str, database:str, port:int=3307) -> Optional[List[str]]:
     """
     Retrieves the list of table names in a MySQL database.
 
@@ -19,12 +19,15 @@ def get_tables(host:str, user:str, password:str, database:str) -> Optional[List[
         user (str): The username to authenticate with.
         password (str): The password for the MySQL user.
         database (str): The name of the database to fetch tables from.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[List[str]]: A list of table names if successful, otherwise None.
     """
+    connection = None
+    cursor = None
     try:
-        connection = connect_to_mysql(host=host, user=user, password=password, database=database)
+        connection = connect_to_mysql(host=host, user=user, password=password, database=database, port=port)
         if not connection:
             logger.error(f"Failed to connect to MYSQL database: '{database}'")
             return None
@@ -44,14 +47,17 @@ def get_tables(host:str, user:str, password:str, database:str) -> Optional[List[
         else:
             logger.info(f"Retrieved tables from database '{database}' successfully")
 
-        cursor.close()
-        connection.close()
         return table_names
     except Error as e:
         logger.exception(f"Error while fetching tables from MySQL database '{database}': {str(e)}")
         return None
+    finally:
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
 
-def get_schema(host:str, user:str, password:str, database:str) -> Optional[Dict[str, list]]:
+def get_schema(host:str, user:str, password:str, database:str, port:int=3307) -> Optional[Dict[str, list]]:
     """
     Retrieves the schema of a given MySQL database as a dictionary.
 
@@ -60,20 +66,23 @@ def get_schema(host:str, user:str, password:str, database:str) -> Optional[Dict[
         user (str): The username to authenticate with.
         password (str): The password for the MySQL user.
         database (str): The name of the database to retrieve the schema from.
+        port (int): The port number for the MySQL server.
 
     Returns:
         Optional[Dict[str, list]]: A dictionary where keys are table names and values are lists of column definitions.
         Returns None if the connection or table retrieval fails.
     """
+    connection = None
+    cursor = None
     try:
-        connection: MySQLConnection = connect_to_mysql(host=host, user=user, password=password, database=database)
+        connection: MySQLConnection = connect_to_mysql(host=host, user=user, password=password, database=database, port=port)
         if not connection:
             logger.error(f"Failed to connect to database : '{database}'")
             return None
 
         cursor: MySQLCursor = connection.cursor(dictionary=True)
 
-        tables = get_tables(host=host, user=user, password=password, database=database)
+        tables = get_tables(host=host, user=user, password=password, database=database, port=port)
         if not tables:
             logger.error(f"Failed to fetch tables from database")   
             return None
@@ -98,16 +107,19 @@ def get_schema(host:str, user:str, password:str, database:str) -> Optional[Dict[
 
             schema[table_name] = column_info
         
-        cursor.close()
-        connection.close()
         logger.info(f"Schema retrieval completed for database: '{database}'")
         return schema
     
     except Error as e:
         logger.error(f"An error occurred while retrieving schema: {str(e)}")
         return None
+    finally:
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()
     
-def get_table_description(host:str, user: str, password:str, database:str, table_name:str) -> Optional[Dict[str, list]]:
+def get_table_description(host:str, user: str, password:str, database:str, table_name:str, port:int=3307) -> Optional[Dict[str, list]]:
     """
     Retrieves the schema of a specific table from a given MySQL database.
 
@@ -117,13 +129,16 @@ def get_table_description(host:str, user: str, password:str, database:str, table
         password (str): The password for the MySQL user.
         database (str): The name of the database containing the table.
         table_name (str): The name of the table to retrieve the schema from.
+        port (int): The port number of the MySQL server.
 
     Returns:
         Optional[Dict[str, list]]: A dictionary where the key is the table name and the value is a list of column definitions.
         Returns None if the connection or schema retrieval fails.
     """
+    connection = None
+    cursor = None
     try:
-        connection = connect_to_mysql(host=host, user=user, password=password, database=database)
+        connection = connect_to_mysql(host=host, user=user, password=password, database=database, port=port)
         if not connection:
             logger.error(f"Failed to connect to database : '{database}'")
             return None
@@ -152,3 +167,8 @@ def get_table_description(host:str, user: str, password:str, database:str, table
     except Error as e:
         logger.error(f"An error occurred while retrieving table description: {str(e)}")
         return None
+    finally:
+        if cursor:
+            cursor.close()
+        if connection:
+            connection.close()

--- a/mysqldb/services/schema.py
+++ b/mysqldb/services/schema.py
@@ -10,7 +10,7 @@ from mysql.connector import MySQLConnection
 
 logger = LoggerFactory.get_logger(__name__)
 
-def get_tables(host:str, user:str, password:str, database:str, port:int=3307) -> Optional[List[str]]:
+def get_tables(host:str, user:str, password:str, database:str, port:int=3306) -> Optional[List[str]]:
     """
     Retrieves the list of table names in a MySQL database.
 
@@ -57,7 +57,7 @@ def get_tables(host:str, user:str, password:str, database:str, port:int=3307) ->
         if connection:
             connection.close()
 
-def get_schema(host:str, user:str, password:str, database:str, port:int=3307) -> Optional[Dict[str, list]]:
+def get_schema(host:str, user:str, password:str, database:str, port:int=3306) -> Optional[Dict[str, list]]:
     """
     Retrieves the schema of a given MySQL database as a dictionary.
 
@@ -119,7 +119,7 @@ def get_schema(host:str, user:str, password:str, database:str, port:int=3307) ->
         if connection:
             connection.close()
     
-def get_table_description(host:str, user: str, password:str, database:str, table_name:str, port:int=3307) -> Optional[Dict[str, list]]:
+def get_table_description(host:str, user: str, password:str, database:str, table_name:str, port:int=3306) -> Optional[Dict[str, list]]:
     """
     Retrieves the schema of a specific table from a given MySQL database.
 


### PR DESCRIPTION
Hi there,

This pull request addresses a few issues that prevent the tool from connecting to a MySQL database on a non-default port and improve overall robustness.

**The Problem:**

1.  The database connection logic did not accept a `port` parameter, causing all connection attempts to fall back to the default port 3306.
2.  The missing `port` parameter needed to be threaded through multiple layers of the application (controller -> services -> connection).
3.  Several functions in the service layer had a bug where they would crash with an `UnboundLocalError` if the initial database connection failed, because the `cursor` and `connection` variables were not guaranteed to be initialized before the `finally` block was executed.

**The Solution:**

-   **`mysqldb/services/connection.py`**: Modified `connect_to_mysql` to accept and use a `port` parameter.
-   **`controllers/mysql_controller.py`**: Updated all `@mcp.tool()` definitions to accept a `port` parameter and pass it to the underlying service functions.
-   **`mysqldb/services/schema.py`**: Updated all service functions to accept a `port` parameter and pass it to the connection function. Also implemented more robust error handling for connection objects.
-   **`mysqldb/services/reads.py`**: Updated all service functions to accept a `port` parameter. Fixed the `UnboundLocalError` bug by initializing `connection` and `cursor` to `None` and checking for their existence before closing them in the `finally` blocks.

These changes make the tool more flexible and resilient. Thank you for your work on this project!